### PR TITLE
Don't pollute Command Palette with commands that need context

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "Other"
   ],
   "activationEvents": [
-    "*"
+    "onView:intersystems-community_servermanager"
   ],
   "main": "./out/main",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "homepage": "https://github.com/george-james-software/gjConnect/README.md",
   "bugs": "https://github.com/george-james-software/gjConnect/issues",
   "license": "GPL-3.0-or-later",
-  
   "keywords": [
     "intersystems",
     "objectscript",
@@ -15,12 +14,14 @@
     "serenji",
     "deltanji"
   ],
-
   "engines": {
     "vscode": "^1.54.0"
   },
   "icon": "images/GeorgeJamesSoftwareLogo.1.gif",
-  "repository": {"type": "git", "url": "https://github.com/george-james-software/gjConnect.git"},
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/george-james-software/gjConnect.git"
+  },
   "categories": [
     "Other"
   ],
@@ -53,46 +54,61 @@
         {
           "command": "serenjidebug.intersystems-servermanager",
           "when": "view == intersystems-community_servermanager && viewItem =~ /namespace$/",
-          "group": "inline@1"        
+          "group": "inline@1"
         },
         {
           "command": "serenji.intersystems-servermanager",
           "when": "view == intersystems-community_servermanager && viewItem =~ /namespace$/",
-          "group": "gjConnect@1"        
+          "group": "gjConnect@1"
         },
         {
           "command": "deltanji.intersystems-servermanager",
           "when": "view == intersystems-community_servermanager && viewItem =~ /namespace$/",
-          "group": "gjConnect@2"        
+          "group": "gjConnect@2"
         },
         {
           "command": "gjLocate.intersystems-servermanager",
           "when": "view == intersystems-community_servermanager && viewItem =~ /namespace$/",
-          "group": "gjConnect@3"     
+          "group": "gjConnect@3"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "serenjidebug.intersystems-servermanager",
+          "when": "false"
+        },
+        {
+          "command": "serenji.intersystems-servermanager",
+          "when": "false"
+        },
+        {
+          "command": "deltanji.intersystems-servermanager",
+          "when": "false"
+        },
+        {
+          "command": "gjLocate.intersystems-servermanager",
+          "when": "false"
         }
       ]
-    }    
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-		"pretest": "npm run compile",
-		"test": "node ./out/test/runTest.js"
+    "pretest": "npm run compile",
+    "test": "node ./out/test/runTest.js"
   },
   "devDependencies": {
-    "vscode-test": "^1.5.1",
+    "@types/glob": "^7.1.1",
+    "@types/mocha": "^5.2.6",
     "@types/node": "^14.0.1",
+    "@types/vscode": "^1.54.0",
+    "glob": "^7.1.4",
+    "mocha": "^6.1.4",
+    "source-map-support": "^0.5.12",
+    "typescript": "^4.2.2",
     "vsce": "^1.87.1",
-		"@types/glob": "^7.1.1",
-		"@types/mocha": "^5.2.6",
-		"@types/vscode": "^1.54.0",
-		"glob": "^7.1.4",
-		"mocha": "^6.1.4",
-		"source-map-support": "^0.5.12",
-		"typescript": "^4.2.2"
-
-  },
-  "dependencies": {
+    "vscode-test": "^1.5.1"
   }
 }


### PR DESCRIPTION
This PR fixes #2 by contributing the commands to `menus/commandPalette` with a `"when": "false"` clause.

It also defers activation of the extension until Server Manager's view displays for the first time:
```json
  "activationEvents": [
    "onView:intersystems-community_servermanager"
  ],
```

Other diffs in `package.json` are a consequence of me having Prettier as my default formatter. Perhaps this repo should recommend/mandate Prettier formatting.